### PR TITLE
Adding cleaning before decimating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,9 @@ set(CMAKE_NINJA_FORCE_RESPONSE_FILE "ON" CACHE BOOL "Force Ninja to use response
 include_directories(vtkbool)
 add_subdirectory(vtkbool)
 add_executable(mainTPMS mainTPMS.cpp Utils.cpp TPMSsolidGenerator.cpp TPMSsheetGenerator.cpp Tpms.cpp)
-target_link_libraries(mainTPMS PRIVATE vtkBool ${VTK_LIBRARIES}
+# target_link_libraries(mainTPMS PRIVATE vtkBool ${VTK_LIBRARIES}
+target_link_libraries(mainTPMS PRIVATE ${VTK_LIBRARIES}
 )
-#target_compile_definitions(Isosurface PRIVATE ${VTK_DEFINITIONS}) #was in branch vtk_v8
 # vtk_module_autoinit is needed
 vtk_module_autoinit(
   TARGETS mainTPMS

--- a/Tpms.cpp
+++ b/Tpms.cpp
@@ -139,7 +139,7 @@ vtkNew <vtkStaticCleanPolyData> Tpms::TpmsClean() {
 vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation(){
 	vtkNew <vtkStaticCleanPolyData> cleaned = TpmsClean();
 	vtkNew<vtkQuadricDecimation> decimate;
-	float reduction = 0.8;
+	float reduction = 0.7;
   	decimate->SetInputData(cleaned->GetOutput());
   	decimate->SetTargetReduction(reduction);
   	decimate->VolumePreservationOn();
@@ -148,40 +148,9 @@ vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation(){
 }
 
 
-
-// vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation() {
-// 	vtkNew<vtkQuadricDecimation> decimate;
-// 	float reduction = 0.8;
-//   	decimate->SetInputData(Surface->GetOutput());
-//   	decimate->SetTargetReduction(reduction);
-//   	decimate->VolumePreservationOn();
-//   	decimate->Update();
-// 	return decimate;
-// }
-
-// vtkNew <vtkPolyDataNormals> Tpms::TpmsNormals(){
-// 	vtkNew<vtkQuadricDecimation> decimate = TpmsQuadricDecimation();
-// 	vtkNew<vtkPolyDataNormals> normals;
-// 	normals->SetInputConnection(decimate->GetOutputPort());
-// 	normals->FlipNormalsOn();
-// 	normals->Update();
-// 	return normals;
-// }
-
-// vtkNew <vtkStaticCleanPolyData> Tpms::TpmsClean(){
-// 	vtkNew<vtkPolyDataNormals> normals = TpmsNormals();
-// 	vtkNew<vtkStaticCleanPolyData> cleaned;
-// 	cleaned->SetInputConnection(normals->GetOutputPort());
-// 	cleaned->SetTolerance(1e-2);
-// 	cleaned->Update();
-// 	return cleaned;
-// }
-
 void Tpms::TpmsWriteToSTL(const char* filename, vtkQuadricDecimation* decimate) {
-// void Tpms::TpmsWriteToSTL(const char* filename, vtkStaticCleanPolyData* cleaned) {
 	vtkNew<vtkSTLWriter> writer;
 	writer->SetInputData(decimate->GetOutput());
-	// writer->SetInputData(cleaned->GetOutput());
 	writer->SetFileName(filename);
 	writer->SetFileTypeToBinary();
 	writer->Update();

--- a/Tpms.cpp
+++ b/Tpms.cpp
@@ -119,10 +119,28 @@ double Tpms::TpmsArea() {
 	return stlArea;
 }
 
-vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation(vtkFlyingEdges3D* intersectTPMS) {
+vtkNew <vtkPolyDataNormals> Tpms::TpmsNormals() {
+	vtkNew<vtkPolyDataNormals> normals;
+	normals->SetInputConnection(Surface->GetOutputPort());
+	normals->FlipNormalsOn();
+	normals->Update();
+	return normals;
+}
+
+vtkNew <vtkStaticCleanPolyData> Tpms::TpmsClean() {
+	vtkNew<vtkPolyDataNormals> normals = TpmsNormals();
+	vtkNew<vtkStaticCleanPolyData> cleaned;
+	cleaned->SetInputConnection(normals->GetOutputPort());
+	cleaned->SetTolerance(1e-3);
+	cleaned->Update();
+	return cleaned;
+}
+
+vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation(){
+	vtkNew <vtkStaticCleanPolyData> cleaned = TpmsClean();
 	vtkNew<vtkQuadricDecimation> decimate;
 	float reduction = 0.8;
-  	decimate->SetInputData(Surface->GetOutput());
+  	decimate->SetInputData(cleaned->GetOutput());
   	decimate->SetTargetReduction(reduction);
   	decimate->VolumePreservationOn();
   	decimate->Update();
@@ -130,9 +148,40 @@ vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation(vtkFlyingEdges3D* inter
 }
 
 
+
+// vtkNew<vtkQuadricDecimation> Tpms::TpmsQuadricDecimation() {
+// 	vtkNew<vtkQuadricDecimation> decimate;
+// 	float reduction = 0.8;
+//   	decimate->SetInputData(Surface->GetOutput());
+//   	decimate->SetTargetReduction(reduction);
+//   	decimate->VolumePreservationOn();
+//   	decimate->Update();
+// 	return decimate;
+// }
+
+// vtkNew <vtkPolyDataNormals> Tpms::TpmsNormals(){
+// 	vtkNew<vtkQuadricDecimation> decimate = TpmsQuadricDecimation();
+// 	vtkNew<vtkPolyDataNormals> normals;
+// 	normals->SetInputConnection(decimate->GetOutputPort());
+// 	normals->FlipNormalsOn();
+// 	normals->Update();
+// 	return normals;
+// }
+
+// vtkNew <vtkStaticCleanPolyData> Tpms::TpmsClean(){
+// 	vtkNew<vtkPolyDataNormals> normals = TpmsNormals();
+// 	vtkNew<vtkStaticCleanPolyData> cleaned;
+// 	cleaned->SetInputConnection(normals->GetOutputPort());
+// 	cleaned->SetTolerance(1e-2);
+// 	cleaned->Update();
+// 	return cleaned;
+// }
+
 void Tpms::TpmsWriteToSTL(const char* filename, vtkQuadricDecimation* decimate) {
+// void Tpms::TpmsWriteToSTL(const char* filename, vtkStaticCleanPolyData* cleaned) {
 	vtkNew<vtkSTLWriter> writer;
 	writer->SetInputData(decimate->GetOutput());
+	// writer->SetInputData(cleaned->GetOutput());
 	writer->SetFileName(filename);
 	writer->SetFileTypeToBinary();
 	writer->Update();

--- a/Tpms.h
+++ b/Tpms.h
@@ -56,12 +56,12 @@ public:
 	double TpmsArea();
 
 	/**
-	 * \brief cleaning the mesh after surface
+	 * \brief Cleaning the mesh after isosurface
 	*/
 	vtkNew <vtkStaticCleanPolyData> TpmsClean();
 
 	/**
-	 * \brief reeducing the mesh
+	 * \brief Reducing mesh size
 	*/
 	vtkNew <vtkQuadricDecimation> TpmsQuadricDecimation();
 
@@ -70,20 +70,6 @@ public:
 	*/
 	vtkNew<vtkPolyDataNormals> TpmsNormals();
 
-	// /**
-	//  * \brief Reduce the mesh
-	// */
-	// vtkNew<vtkQuadricDecimation> TpmsQuadricDecimation();
-
-	// /**
-	//  * \brief Flip normals orientiation
-	// */
-	// vtkNew<vtkPolyDataNormals> TpmsNormals();
-
-	// /**
-	//  * \brief Clean the otuput mesh
-	// */
-	// vtkNew<vtkStaticCleanPolyData> TpmsClean();
 
 	/**
 	*  \brief Write the Tpms to the stl file

--- a/Tpms.h
+++ b/Tpms.h
@@ -6,6 +6,8 @@
 #include <vtkMassProperties.h>
 #include <vtkSTLWriter.h>
 #include <vtkQuadricDecimation.h>
+#include <vtkStaticCleanPolyData.h>
+#include <vtkPolyDataNormals.h>
 
 #include "Definition.h"
 #include "Utils.h"
@@ -53,17 +55,42 @@ public:
 	*/
 	double TpmsArea();
 
+	/**
+	 * \brief cleaning the mesh after surface
+	*/
+	vtkNew <vtkStaticCleanPolyData> TpmsClean();
 
 	/**
-	 * \brief Reduce the mesh
+	 * \brief reeducing the mesh
 	*/
-	vtkNew<vtkQuadricDecimation> TpmsQuadricDecimation(vtkFlyingEdges3D* intersectTPMS);
+	vtkNew <vtkQuadricDecimation> TpmsQuadricDecimation();
+
+	/**
+	 * \brief Flip normals orientiation
+	*/
+	vtkNew<vtkPolyDataNormals> TpmsNormals();
+
+	// /**
+	//  * \brief Reduce the mesh
+	// */
+	// vtkNew<vtkQuadricDecimation> TpmsQuadricDecimation();
+
+	// /**
+	//  * \brief Flip normals orientiation
+	// */
+	// vtkNew<vtkPolyDataNormals> TpmsNormals();
+
+	// /**
+	//  * \brief Clean the otuput mesh
+	// */
+	// vtkNew<vtkStaticCleanPolyData> TpmsClean();
 
 	/**
 	*  \brief Write the Tpms to the stl file
 	*  @param filename Output filename
 	*/
 	void TpmsWriteToSTL(const char* filename, vtkQuadricDecimation* decimate);
+	// void TpmsWriteToSTL(const char* filename, vtkStaticCleanPolyData* cleaned);
 
 
 	/**

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -67,7 +67,6 @@ double* convertOrigin(string origin) {
 #ifdef GRAPHICAL
 
 void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate) {
-// void renderSurface(vtkFlyingEdges3D* surface, vtkStaticCleanPolyData* cleaned) {
 
 	vtkNew<vtkNamedColors> colors;
 
@@ -83,7 +82,6 @@ void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate) {
 
 	vtkNew<vtkPolyDataMapper> mapper;
 	mapper->SetInputConnection(decimate->GetOutputPort());
-	// mapper->SetInputConnection(cleaned->GetOutputPort());
 
 	mapper->ScalarVisibilityOff();
 

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -67,6 +67,7 @@ double* convertOrigin(string origin) {
 #ifdef GRAPHICAL
 
 void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate) {
+// void renderSurface(vtkFlyingEdges3D* surface, vtkStaticCleanPolyData* cleaned) {
 
 	vtkNew<vtkNamedColors> colors;
 
@@ -82,6 +83,7 @@ void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate) {
 
 	vtkNew<vtkPolyDataMapper> mapper;
 	mapper->SetInputConnection(decimate->GetOutputPort());
+	// mapper->SetInputConnection(cleaned->GetOutputPort());
 
 	mapper->ScalarVisibilityOff();
 

--- a/Utils.h
+++ b/Utils.h
@@ -93,7 +93,6 @@ void printTime(clock_t start, clock_t end);
 */
 #ifdef GRAPHICAL
 void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate);
-// void renderSurface(vtkFlyingEdges3D* surface, vtkStaticCleanPolyData* cleaned);
 #endif // GRAPHICAL
 
 

--- a/Utils.h
+++ b/Utils.h
@@ -25,6 +25,7 @@
 #include <vtkNamedColors.h>
 #include <vtkProperty.h>
 #include <vtkQuadricDecimation.h>
+#include <vtkStaticCleanPolyData.h>
 
 #endif // GRAPHICAL
 
@@ -92,6 +93,7 @@ void printTime(clock_t start, clock_t end);
 */
 #ifdef GRAPHICAL
 void renderSurface(vtkFlyingEdges3D* surface, vtkQuadricDecimation* decimate);
+// void renderSurface(vtkFlyingEdges3D* surface, vtkStaticCleanPolyData* cleaned);
 #endif // GRAPHICAL
 
 

--- a/mainTPMS.cpp
+++ b/mainTPMS.cpp
@@ -82,7 +82,12 @@ int main(int argc, char* argv[])
 	double stlArea = tpms_final.TpmsArea();
 
 	// Reducing mesh size
-	vtkNew<vtkQuadricDecimation> decimate = tpms_final.TpmsQuadricDecimation(surface);
+	// vtkNew<vtkQuadricDecimation> decimate = tpms_final.TpmsQuadricDecimation(surface);
+
+	// Flipping the normals
+	// vtkNew<vtkStaticCleanPolyData> cleaned = tpms_final.TpmsClean();
+
+	vtkNew<vtkQuadricDecimation> decimate = tpms_final.TpmsQuadricDecimation();
 
 
 	double volFracFinal = stlVol / (tarSize * tarSize * tarSize);
@@ -94,6 +99,7 @@ int main(int argc, char* argv[])
 
 	if (saveSTL) {
 		tpms_final.TpmsWriteToSTL(out_file,decimate);
+		// tpms_final.TpmsWriteToSTL(out_file, cleaned);
 	}
 
 
@@ -108,6 +114,7 @@ int main(int argc, char* argv[])
 #ifdef GRAPHICAL
 	if (graph)
 		renderSurface(surface, decimate);
+		// renderSurface(surface, cleaned);
 #endif // GRAPHICAL
 
 

--- a/mainTPMS.cpp
+++ b/mainTPMS.cpp
@@ -81,12 +81,6 @@ int main(int argc, char* argv[])
 	double stlVol = tpms_final.TpmsVolume();
 	double stlArea = tpms_final.TpmsArea();
 
-	// Reducing mesh size
-	// vtkNew<vtkQuadricDecimation> decimate = tpms_final.TpmsQuadricDecimation(surface);
-
-	// Flipping the normals
-	// vtkNew<vtkStaticCleanPolyData> cleaned = tpms_final.TpmsClean();
-
 	vtkNew<vtkQuadricDecimation> decimate = tpms_final.TpmsQuadricDecimation();
 
 
@@ -99,7 +93,6 @@ int main(int argc, char* argv[])
 
 	if (saveSTL) {
 		tpms_final.TpmsWriteToSTL(out_file,decimate);
-		// tpms_final.TpmsWriteToSTL(out_file, cleaned);
 	}
 
 
@@ -114,7 +107,6 @@ int main(int argc, char* argv[])
 #ifdef GRAPHICAL
 	if (graph)
 		renderSurface(surface, decimate);
-		// renderSurface(surface, cleaned);
 #endif // GRAPHICAL
 
 


### PR DESCRIPTION
Added StaticCleanPolyData filter and flip normals (PolyDataNormals) before QuadricDecimation.
Tolerance is set to 1e-3, but can be increased if very large size of mesh, as well as the reduction used for QuadricDecimation (set as 0.7).